### PR TITLE
add tag

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -19,7 +19,7 @@ jobs:
           - main
           - v2025.3
           - v2025.4
-          - action-unifier
+          - v2025.5
 
     steps:
       -


### PR DESCRIPTION
We changed the default cmo/cmi for the fl-jikken-unifier to be the one compiled using Ubuntu.
Hence. there's no need to keep the `action-unifier` tag (for now). Instead we are adding the v2025.5